### PR TITLE
Fix for newer Mojolicious

### DIFF
--- a/Mojolicious-Plugin-MozPersona/lib/Mojolicious/Plugin/MozPersona/Controller.pm
+++ b/Mojolicious-Plugin-MozPersona/lib/Mojolicious/Plugin/MozPersona/Controller.pm
@@ -120,9 +120,9 @@ sub signin {
     my $result = '';
 
     eval {
-        $persona_response = $self->ua->post_form(
+        $persona_response = $self->ua->post(
            $self->stash('_persona_service')
-           => {
+           => form => {
                 assertion => $self->param('assertion'),
                 audience  => $self->stash('_persona_audience'), 
            }


### PR DESCRIPTION
it seems that UA->post_form is deprecated in favor of
->post($url, form => {...})
