### PR TITLE
Default to Mojolicious' built-in jquery

### DIFF
--- a/Mojolicious-Plugin-MozPersona/lib/Mojolicious/Plugin/MozPersona.pm
+++ b/Mojolicious-Plugin-MozPersona/lib/Mojolicious/Plugin/MozPersona.pm
@@ -163,7 +163,7 @@ This option is deactivated (set to C<0>) by default.
 =item jquery
 
 Include the jQuery JavaScript Library that is part of the Mojolicious distribution
-by inserting an appropriate C<E<lt>script src="/js/jquery.js"E<gt>> element.
+by inserting an appropriate C<E<lt>script src="/mojo/jquery/jquery.js"E<gt>> element.
 
 =item persona
 
@@ -310,7 +310,7 @@ sub register {
             $head_block .= '<link href="/_persona/persona-buttons.css" media="screen" rel="stylesheet" type="text/css" />';
         }
         if ( $conf{'autoHook'}->{'jquery'} ) {
-            $head_block .= '<script src="/js/jquery.js" type="text/javascript"></script>';
+            $head_block .= '<script src="/mojo/jquery/jquery.js" type="text/javascript"></script>';
         }
 
         my $end_block = '';


### PR DESCRIPTION
Mojolicious comes with jquery enabled under the /mojo/jquery/jquery.js URL.
Use that by default, so that users do not have to ship their own.
